### PR TITLE
Handle type assertion error & some fix

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
-	atgen "github.com/mizzy/atgen/lib"
+	"github.com/mizzy/atgen/lib"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )

--- a/commands.go
+++ b/commands.go
@@ -24,12 +24,12 @@ var commandGen = cli.Command{
 	Action: doGen,
 	Flags: []cli.Flag{
 		cli.StringFlag{
-			Name:  "templateDir",
+			Name:  "templateDir, t",
 			Value: ".",
 			Usage: "template directory that has template yaml and code",
 		},
 		cli.StringFlag{
-			Name:  "outputDir",
+			Name:  "outputDir, o",
 			Value: ".",
 			Usage: "output directory to write generated test files",
 		},

--- a/lib/generator.go
+++ b/lib/generator.go
@@ -31,7 +31,10 @@ func (g *Generator) Generate() error {
 			return errors.WithStack(err)
 		}
 		defer f.Close()
-		g.generateTestFuncs(v, t, f)
+		err = g.generateTestFuncs(v, t, f)
+		if err != nil {
+			return errors.WithStack(err)
+		}
 	}
 	return nil
 }

--- a/lib/generator_test.go
+++ b/lib/generator_test.go
@@ -4,12 +4,24 @@ import (
 	"testing"
 )
 
-func TestFilterTestFunc(t *testing.T) {
-	parsed, err := parseYaml([]byte(yamlTestFuncPerAPIVersion))
+func parseAndConvertToTestFuncs(t *testing.T, yaml string) map[string]TestFuncs {
+	t.Helper()
+
+	parsed, err := parseYaml([]byte(yaml))
 	if err != nil {
 		t.Fatal(err)
 	}
-	tfuncs := filterTestFuncs(convertToTestFuncs(parsed))
+
+	testFuncs, err := convertToTestFuncs(parsed)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return filterTestFuncs(testFuncs)
+}
+
+func TestFilterTestFunc(t *testing.T) {
+	tfuncs := parseAndConvertToTestFuncs(t, yamlTestFuncPerAPIVersion)
 
 	if tfuncs["v1beta1"][0].Vars["key"] != "val" {
 		t.Fatalf(`tfuncs["v1beta1"][0].Vars["key"] should be val`)
@@ -27,11 +39,7 @@ func TestFilterTestFunc(t *testing.T) {
 }
 
 func TestFilterTest(t *testing.T) {
-	parsed, err := parseYaml([]byte(yamlTestPerAPIVersion))
-	if err != nil {
-		t.Fatal(err)
-	}
-	tfuncs := filterTestFuncs(convertToTestFuncs(parsed))
+	tfuncs := parseAndConvertToTestFuncs(t, yamlTestPerAPIVersion)
 
 	v1beta1 := tfuncs["v1beta1"][0].Tests[0].(Test)
 	if v1beta1.Path != "/v1beta1/user" {
@@ -45,11 +53,7 @@ func TestFilterTest(t *testing.T) {
 }
 
 func TestFilterTestFuncAndTest(t *testing.T) {
-	parsed, err := parseYaml([]byte(yamlTestFuncAndTestPerAPIVersion))
-	if err != nil {
-		t.Fatal(err)
-	}
-	tfuncs := filterTestFuncs(convertToTestFuncs(parsed))
+	tfuncs := parseAndConvertToTestFuncs(t, yamlTestFuncAndTestPerAPIVersion)
 
 	v1beta1 := tfuncs["v1beta1"][0].Tests[0].(Test)
 	if v1beta1.Path != "/v1beta1/user" {
@@ -73,11 +77,7 @@ func TestFilterTestFuncAndTest(t *testing.T) {
 }
 
 func TestFilterTestFuncAndSubtests(t *testing.T) {
-	parsed, err := parseYaml([]byte(yamlTestFuncWithSubtests))
-	if err != nil {
-		t.Fatal(err)
-	}
-	tfuncs := filterTestFuncs(convertToTestFuncs(parsed))
+	tfuncs := parseAndConvertToTestFuncs(t, yamlTestFuncWithSubtests)
 
 	subtest := tfuncs["v1"][0].Tests[2].(Subtests)[0]
 	if subtest.Name != "SubFoo" {

--- a/lib/parser.go
+++ b/lib/parser.go
@@ -4,7 +4,7 @@ import (
 	"io/ioutil"
 
 	"github.com/pkg/errors"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 )
 
 // ParseYaml parsed yaml which deifnes test requests/responses

--- a/lib/parser.go
+++ b/lib/parser.go
@@ -58,14 +58,26 @@ func convertToTestFuncs(parsed []map[interface{}]interface{}) (TestFuncs, error)
 			}
 		}
 
-		testFunc.Vars = convertToParams(p["vars"])
+		vars, err := convertToParams(p["vars"])
+		if err != nil {
+			return testFuncs, err
+		}
+		testFunc.Vars = vars
 
 		for _, t := range p["tests"].([]interface{}) {
 			t := t.(map[interface{}]interface{})
 			if t["path"] != nil {
-				testFunc.Tests = append(testFunc.Tests, convertToTest(t))
+				test, err := convertToTest(t)
+				if err != nil {
+					return testFuncs, err
+				}
+				testFunc.Tests = append(testFunc.Tests, test)
 			} else {
-				testFunc.Tests = append(testFunc.Tests, convertToSubtests(t))
+				subtests, err := convertToSubtests(t)
+				if err != nil {
+					return testFuncs, err
+				}
+				testFunc.Tests = append(testFunc.Tests, subtests)
 			}
 		}
 		testFuncs = append(testFuncs, testFunc)
@@ -73,7 +85,7 @@ func convertToTestFuncs(parsed []map[interface{}]interface{}) (TestFuncs, error)
 	return testFuncs, nil
 }
 
-func convertToTest(t map[interface{}]interface{}) Test {
+func convertToTest(t map[interface{}]interface{}) (Test, error) {
 	var apiVersions []string
 	if t["apiVersions"] != nil {
 		for _, v := range t["apiVersions"].([]interface{}) {
@@ -81,17 +93,30 @@ func convertToTest(t map[interface{}]interface{}) Test {
 		}
 	}
 
+	req, err := convertToReq(t["req"])
+	if err != nil {
+		return Test{}, err
+	}
+	res, err := convertToRes(t["res"])
+	if err != nil {
+		return Test{}, err
+	}
+	vars, err := convertToParams(t["vars"])
+	if err != nil {
+		return Test{}, err
+	}
+
 	return Test{
 		APIVersions: apiVersions,
 		Path:        t["path"].(string),
 		Method:      t["method"].(string),
-		Req:         convertToReq(t["req"]),
-		Res:         convertToRes(t["res"]),
-		Vars:        convertToParams(t["vars"]),
-	}
+		Req:         req,
+		Res:         res,
+		Vars:        vars,
+	}, nil
 }
 
-func convertToSubtests(s map[interface{}]interface{}) Subtests {
+func convertToSubtests(s map[interface{}]interface{}) (Subtests, error) {
 	subTests := Subtests{}
 
 	for _, s := range s["subtests"].([]interface{}) {
@@ -99,64 +124,114 @@ func convertToSubtests(s map[interface{}]interface{}) Subtests {
 		subtest := Subtest{Name: s["name"].(string)}
 		for _, t := range s["tests"].([]interface{}) {
 			t := t.(map[interface{}]interface{})
-			subtest.Tests = append(subtest.Tests, convertToTest(t))
+			test, err := convertToTest(t)
+			if err != nil {
+				return subTests, err
+			}
+			subtest.Tests = append(subtest.Tests, test)
 		}
 		subTests = append(subTests, subtest)
 	}
-	return subTests
+	return subTests, nil
 }
 
-func convertToReq(r interface{}) Req {
+func convertToReq(r interface{}) (Req, error) {
 	if r == nil {
-		return Req{}
+		return Req{}, nil
 	}
 
 	req := r.(map[interface{}]interface{})
-	return Req{
-		Params:  convertToParams(req["params"]),
-		Headers: convertToHeaders(req["headers"]),
+
+	headers, err := convertToHeaders(req["headers"])
+	if err != nil {
+		return Req{}, nil
 	}
+
+	params, err := convertToParams(req["params"])
+	if err != nil {
+		return Req{}, err
+	}
+
+	return Req{
+		Params:  params,
+		Headers: headers,
+	}, nil
 }
 
-func convertToRes(r interface{}) Res {
+func convertToRes(r interface{}) (Res, error) {
 	if r == nil {
-		return Res{}
+		return Res{}, nil
 	}
 
 	res := r.(map[interface{}]interface{})
+
+	headers, err := convertToHeaders(res["headers"])
+	if err != nil {
+		return Res{}, err
+	}
+
+	params, err := convertToParams(res["params"])
+	if err != nil {
+		return Res{}, err
+	}
+
 	return Res{
 		Status:  res["status"].(int),
-		Params:  convertToParams(res["params"]),
-		Headers: convertToHeaders(res["headers"]),
-	}
+		Params:  params,
+		Headers: headers,
+	}, nil
 }
 
-func convertToParams(p interface{}) map[string]interface{} {
+func convertToParams(p interface{}) (map[string]interface{}, error) {
 	params := make(map[string]interface{})
 	if p != nil {
 		for k, v := range p.(map[interface{}]interface{}) {
+			key, ok := k.(string)
+			if !ok {
+				return params, errors.New("key should be string")
+			}
+
 			switch t := v.(type) {
 			case string, bool, int:
-				params[k.(string)] = t
+				params[key] = t
 			case map[interface{}]interface{}:
-				params[k.(string)] = convertToParams(t)
-			case []interface{}:
-				params[k.(string)] = []map[string]interface{}{}
-				for _, v := range t {
-					params[k.(string)] = append(params[k.(string)].([]map[string]interface{}), convertToParams(v))
+				p, err := convertToParams(t)
+				if err != nil {
+					return params, err
 				}
+				params[key] = p
+			case []interface{}:
+				params[key] = []map[string]interface{}{}
+				for _, v := range t {
+					p, err := convertToParams(v)
+					if err != nil {
+						return params, err
+					}
+					params[key] = append(params[key].([]map[string]interface{}), p)
+				}
+			default:
+				return params, errors.New("invalid type")
 			}
 		}
 	}
-	return params
+	return params, nil
 }
 
-func convertToHeaders(h interface{}) map[string]string {
+func convertToHeaders(h interface{}) (map[string]string, error) {
 	headers := make(map[string]string)
 	if h != nil {
 		for k, v := range h.(map[interface{}]interface{}) {
-			headers[k.(string)] = v.(string)
+			key, ok := k.(string)
+			if !ok {
+				return headers, errors.New("header key must be string")
+			}
+
+			val, ok := v.(string)
+			if !ok {
+				return headers, errors.New("header val must be string")
+			}
+			headers[key] = val
 		}
 	}
-	return headers
+	return headers, nil
 }

--- a/lib/parser_test.go
+++ b/lib/parser_test.go
@@ -4,13 +4,23 @@ import (
 	"testing"
 )
 
+func convertToTestFuncsHelper(t *testing.T, parsed []map[interface{}]interface{}) TestFuncs {
+	t.Helper()
+
+	funcs, err := convertToTestFuncs(parsed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return funcs
+}
+
 func TestParseTestFuncPerAPIVersion(t *testing.T) {
 	parsed, err := parseYaml([]byte(yamlTestFuncPerAPIVersion))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	testFuncs := convertToTestFuncs(parsed)
+	testFuncs := convertToTestFuncsHelper(t, parsed)
 	testFunc := testFuncs[0]
 
 	if testFunc.Name != "TestFoo" {
@@ -41,7 +51,7 @@ func TestParseTestPerAPIVersion(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testFuncs := convertToTestFuncs(parsed)
+	testFuncs := convertToTestFuncsHelper(t, parsed)
 	testFunc := testFuncs[0]
 
 	if testFunc.Name != "TestFoo" {
@@ -65,7 +75,7 @@ func TestParseTestFuncAndTestPerAPIVersion(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testFuncs := convertToTestFuncs(parsed)
+	testFuncs := convertToTestFuncsHelper(t, parsed)
 	testFunc := testFuncs[0]
 
 	if testFunc.Name != "TestFoo" {
@@ -88,7 +98,7 @@ func TestParseTestFuncWithSubtests(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testFuncs := convertToTestFuncs(parsed)
+	testFuncs := convertToTestFuncsHelper(t, parsed)
 	testFunc := testFuncs[0]
 
 	if testFunc.Name != "TestWithSubtests" {
@@ -123,7 +133,7 @@ func TestGetVersionsOfTestFunc(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	testFuncs := convertToTestFuncs(parsed)
+	testFuncs := convertToTestFuncsHelper(t, parsed)
 	versions := getVersions(testFuncs[0])
 
 	if versions[0] != "v1beta1" {
@@ -144,7 +154,7 @@ func TestGetVersionsOfTest(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	testFuncs := convertToTestFuncs(parsed)
+	testFuncs := convertToTestFuncsHelper(t, parsed)
 	versions := getVersions(testFuncs[0])
 
 	if len(versions) != 3 {
@@ -170,7 +180,7 @@ func TestGetVersionsOfTestFuncAndTest(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	testFuncs := convertToTestFuncs(parsed)
+	testFuncs := convertToTestFuncsHelper(t, parsed)
 	versions := getVersions(testFuncs[0])
 
 	if len(versions) != 3 {


### PR DESCRIPTION
YAML の parse の際に type assertion して error が起こりそうなところをハンドリングするようにしました。

あとは以下の細かい修正を加えています

* import 文の不要な alias を削除
* 短いオプションを追加